### PR TITLE
Times & UWP support updating

### DIFF
--- a/src/PCLExt.FileStorage.NetFX/DefaultFileImplementation.cs
+++ b/src/PCLExt.FileStorage.NetFX/DefaultFileImplementation.cs
@@ -31,6 +31,18 @@ namespace PCLExt.FileStorage
         public bool Exists => File.Exists(Path);
         /// <inheritdoc />
         public long Size => Exists ? new FileInfo(Path).Length : -1;
+        /// <inheritdoc />
+        public DateTime CreationTime => File.GetCreationTime(Path);
+        /// <inheritdoc />
+        public DateTime CreationTimeUTC => File.GetCreationTimeUtc(Path);
+        /// <inheritdoc />
+        public DateTime LastAccessTime => File.GetLastAccessTime(Path);
+        /// <inheritdoc />
+        public DateTime LastAccessTimeUTC => File.GetLastAccessTimeUtc(Path);
+        /// <inheritdoc />
+        public DateTime LastWriteTime => File.GetLastWriteTime(Path);
+        /// <inheritdoc />
+        public DateTime LastWriteTimeUTC => File.GetLastWriteTimeUtc(Path);
 
         /// <summary>
         /// Creates a new <see cref="IFile"/> corresponding to the specified path.

--- a/src/PCLExt.FileStorage.Portable111/Files/FileFromPath.cs
+++ b/src/PCLExt.FileStorage.Portable111/Files/FileFromPath.cs
@@ -1,4 +1,8 @@
-﻿namespace PCLExt.FileStorage.Files
+﻿#if WINDOWS_UWP
+using PCLExt.FileStorage.UWP;
+#endif
+
+namespace PCLExt.FileStorage.Files
 {
     /// <summary>
     /// Represents a folder created by a given path
@@ -19,6 +23,11 @@
                 return new DefaultFileImplementation(path);
             else
                 throw new Exceptions.FileNotFoundException($"File does not exists on {path}");
+#elif WINDOWS_UWP
+            var result = new StorageFileImplementation(path);
+            if(!result.Exists)
+                throw new Exceptions.FileNotFoundException($"File does not exists on {path}");
+            return result;
 #endif
 
             throw Exceptions.ExceptionsHelper.NotImplementedInReferenceAssembly();

--- a/src/PCLExt.FileStorage.Portable111/Folders/ApplicationRootFolder.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/ApplicationRootFolder.cs
@@ -21,7 +21,8 @@
 #elif NETSTANDARD2_0
             return new DefaultFolderImplementation(System.AppContext.BaseDirectory);
 #elif WINDOWS_UWP
-            return null;
+            return new UWP.StorageFolderImplementation(
+                Windows.ApplicationModel.Package.Current.InstalledLocation);
 #endif
         }
 #else

--- a/src/PCLExt.FileStorage.Portable111/Folders/DocumentsRootFolder.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/DocumentsRootFolder.cs
@@ -18,10 +18,8 @@ namespace PCLExt.FileStorage.Folders
             return new DefaultFolderImplementation(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments));
 #elif DESKTOP || __MACOS__ || NETSTANDARD2_0
             return new DefaultFolderImplementation(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments)).GetDataFolder();
-#elif WINDOWS_UWP
-            return null;
-            // TODO
-            return new DefaultFolderImplementation(Windows.Storage.KnownFolders.DocumentsLibrary.Path);
+#elif WINDOWS_UWP            
+            return new UWP.StorageFolderImplementation(Windows.Storage.KnownFolders.DocumentsLibrary);
 #endif
         }
 #else

--- a/src/PCLExt.FileStorage.Portable111/Folders/FolderFromPath.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/FolderFromPath.cs
@@ -16,6 +16,8 @@
 
 #if DESKTOP || ANDROID || __IOS__ || __MACOS__ || NETSTANDARD2_0
             return System.IO.Directory.Exists(path) ? new DefaultFolderImplementation(path, true) : null;
+#elif WINDOWS_UWP
+            return new UWP.StorageFolderImplementation(path);
 #endif
 
             throw Exceptions.ExceptionsHelper.NotImplementedInReferenceAssembly();

--- a/src/PCLExt.FileStorage.Portable111/Folders/LocalRootFolder.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/LocalRootFolder.cs
@@ -45,8 +45,8 @@ namespace PCLExt.FileStorage.Folders
 #elif DESKTOP || NETSTANDARD2_0
             return new DefaultFolderImplementation(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData)).GetDataFolder();
 #elif WINDOWS_UWP
-            return null;
-            return new DefaultFolderImplementation(Windows.Storage.ApplicationData.Current.LocalFolder.Path);
+            return new UWP.StorageFolderImplementation(
+                Windows.Storage.ApplicationData.Current.LocalFolder);
 #endif
         }
 #else

--- a/src/PCLExt.FileStorage.Portable111/Folders/RoamingRootFolder.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/RoamingRootFolder.cs
@@ -21,8 +21,8 @@ namespace PCLExt.FileStorage.Folders
 #elif DESKTOP || __MACOS__ || NETSTANDARD2_0
             return new DefaultFolderImplementation(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData)).GetDataFolder();
 #elif WINDOWS_UWP
-            return null;
-            return new DefaultFolderImplementation(Windows.Storage.ApplicationData.Current.RoamingFolder.Path);
+            return new UWP.StorageFolderImplementation(
+                Windows.Storage.ApplicationData.Current.RoamingFolder);
 #endif
         }
 #else

--- a/src/PCLExt.FileStorage.Portable111/Folders/TempRootFolder.cs
+++ b/src/PCLExt.FileStorage.Portable111/Folders/TempRootFolder.cs
@@ -13,8 +13,8 @@
         private static IFolder GetTempFolder()
         {
 #if WINDOWS_UWP
-            return null;
-            return new DefaultFolderImplementation(Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+             return new UWP.StorageFolderImplementation(
+                Windows.Storage.ApplicationData.Current.TemporaryFolder);
 #else
             return new DefaultFolderImplementation(System.IO.Path.GetTempPath());
 #endif

--- a/src/PCLExt.FileStorage.Portable111/PortablePath.cs
+++ b/src/PCLExt.FileStorage.Portable111/PortablePath.cs
@@ -23,8 +23,8 @@ namespace PCLExt.FileStorage
         {
             get
             {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
-				return System.IO.Path.DirectorySeparatorChar;
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
+                return System.IO.Path.DirectorySeparatorChar;
 #endif
 
 				throw ExceptionsHelper.NotImplementedInReferenceAssembly();
@@ -38,7 +38,7 @@ namespace PCLExt.FileStorage
         /// <returns>A combined path.</returns>
         public static string Combine(params string[] paths)
         {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
 			return System.IO.Path.Combine(paths);
 #endif
 
@@ -58,8 +58,8 @@ namespace PCLExt.FileStorage
         /// <exception cref="System.ArgumentException"><paramref name="path" /> contains one or more invalid characters.</exception>
         public static string GetExtension(string path)
         {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
-			return System.IO.Path.GetExtension(path);
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
+            return System.IO.Path.GetExtension(path);
 #endif
 
             throw ExceptionsHelper.NotImplementedInReferenceAssembly();
@@ -82,8 +82,8 @@ namespace PCLExt.FileStorage
         /// <exception cref="System.ArgumentException"><paramref name="path" /> contains one or more invalid characters.</exception>
         public static string GetFileName(string path)
         {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
-			return System.IO.Path.GetFileName(path);
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
+            return System.IO.Path.GetFileName(path);
 #endif
 
             throw ExceptionsHelper.NotImplementedInReferenceAssembly();
@@ -101,8 +101,8 @@ namespace PCLExt.FileStorage
         /// <exception cref="System.ArgumentException"><paramref name="path" /> contains one or more invalid characters.</exception>
         public static string GetFileNameWithoutExtension(string path)
         {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
-			return System.IO.Path.GetFileNameWithoutExtension(path);
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
+            return System.IO.Path.GetFileNameWithoutExtension(path);
 #endif
 
             throw ExceptionsHelper.NotImplementedInReferenceAssembly();
@@ -121,8 +121,8 @@ namespace PCLExt.FileStorage
         /// <exception cref="System.ArgumentException"><paramref name="path" /> contains one or more invalid characters.</exception>
         public static bool HasExtension(string path)
         {
-#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__
-			return System.IO.Path.HasExtension(path);
+#if NETSTANDARD2_0 || DESKTOP || __MACOS__ || ANDROID || __IOS__ || WINDOWS_UWP
+            return System.IO.Path.HasExtension(path);
 #endif
 
             throw ExceptionsHelper.NotImplementedInReferenceAssembly();

--- a/src/PCLExt.FileStorage.Standard.Abstractions/BaseFile.cs
+++ b/src/PCLExt.FileStorage.Standard.Abstractions/BaseFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,7 +18,18 @@ namespace PCLExt.FileStorage
         public bool Exists => _file.Exists;
         /// <inheritdoc />
         public long Size => _file.Size;
-
+        /// <inheritdoc />
+        public DateTime CreationTime => _file.CreationTime;
+        /// <inheritdoc />
+        public DateTime CreationTimeUTC => _file.CreationTimeUTC;
+        /// <inheritdoc />
+        public DateTime LastAccessTime => _file.LastAccessTime;
+        /// <inheritdoc />
+        public DateTime LastAccessTimeUTC => _file.LastAccessTimeUTC;
+        /// <inheritdoc />
+        public DateTime LastWriteTime => _file.LastWriteTime;
+        /// <inheritdoc />
+        public DateTime LastWriteTimeUTC => _file.LastWriteTimeUTC;
 
         /// <summary>
         /// Wraps an <see cref="IFile"/>

--- a/src/PCLExt.FileStorage.Standard.Abstractions/IFile.cs
+++ b/src/PCLExt.FileStorage.Standard.Abstractions/IFile.cs
@@ -7,6 +7,7 @@
 // Which is released under the MS-PL license.
 //-----------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,6 +52,42 @@ namespace PCLExt.FileStorage
         /// Size of the file.
         /// </summary>
         long Size { get; }
+
+         /// <summary>
+         /// Creation time.
+         /// </summary>
+         /// <value>The creation time.</value>
+         DateTime CreationTime { get; }
+ 
+         /// <summary>
+         /// Creation time UTC.
+         /// </summary>
+         /// <value>The creation time UTC.</value>
+         DateTime CreationTimeUTC { get; }
+ 
+         /// <summary>
+         /// Last access time.
+         /// </summary>
+         /// <value>The last access time.</value>
+         DateTime LastAccessTime { get; }
+ 
+         /// <summary>
+         /// Last access time UTC.
+         /// </summary>
+         /// <value>The last access time UTC.</value>
+         DateTime LastAccessTimeUTC { get; }
+ 
+         /// <summary>
+         /// Last write time.
+         /// </summary>
+         /// <value>The last write time.</value>
+         DateTime LastWriteTime { get; }
+ 
+         /// <summary>
+         /// Last write time UTC.
+         /// </summary>
+         /// <value>The last write time UTC.</value>
+         DateTime LastWriteTimeUTC { get; }
 
         /// <summary>
         /// Opens the file

--- a/src/PCLExt.FileStorage.UWP/Extensions/StorageExtensions.cs
+++ b/src/PCLExt.FileStorage.UWP/Extensions/StorageExtensions.cs
@@ -20,7 +20,7 @@ namespace PCLExt.FileStorage.UWP.Extensions
             if (collisionOption == NameCollisionOption.ReplaceExisting)
                 return Windows.Storage.NameCollisionOption.ReplaceExisting;
 
-            throw new NotSupportedException(collisionOption.ToString());
+            throw new ArgumentException(collisionOption.ToString());
         }
 
         public static CreationCollisionOption ConvertToCreationCollision(
@@ -33,7 +33,7 @@ namespace PCLExt.FileStorage.UWP.Extensions
             if (collisionOption == NameCollisionOption.ReplaceExisting)
                 return CreationCollisionOption.ReplaceExisting;
 
-            throw new NotSupportedException(collisionOption.ToString());
+            throw new ArgumentException(collisionOption.ToString());
         }
 
         public static Windows.Storage.CreationCollisionOption ConvertToWindowsCreationCollisionOption(
@@ -48,7 +48,7 @@ namespace PCLExt.FileStorage.UWP.Extensions
             if (collisionOption == CreationCollisionOption.OpenIfExists)
                 return Windows.Storage.CreationCollisionOption.OpenIfExists;
 
-            throw new NotSupportedException(collisionOption.ToString());
+            throw new ArgumentException(collisionOption.ToString());
         }
     }
 }

--- a/src/PCLExt.FileStorage.UWP/Extensions/StorageExtensions.cs
+++ b/src/PCLExt.FileStorage.UWP/Extensions/StorageExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PCLExt.FileStorage.UWP.Extensions
+{
+    sealed class StorageExtensions
+    {
+        public static Windows.Storage.NameCollisionOption ConvertToNameCollision(
+           NameCollisionOption collisionOption)
+        {
+            if (collisionOption == NameCollisionOption.FailIfExists)
+                return Windows.Storage.NameCollisionOption.FailIfExists;
+
+            if (collisionOption == NameCollisionOption.GenerateUniqueName)
+                return Windows.Storage.NameCollisionOption.GenerateUniqueName;
+
+            if (collisionOption == NameCollisionOption.ReplaceExisting)
+                return Windows.Storage.NameCollisionOption.ReplaceExisting;
+
+            throw new NotSupportedException(collisionOption.ToString());
+        }
+
+        public static CreationCollisionOption ConvertToCreationCollision(
+            NameCollisionOption collisionOption)
+        {
+            if (collisionOption == NameCollisionOption.FailIfExists)
+                return CreationCollisionOption.FailIfExists;
+            if (collisionOption == NameCollisionOption.GenerateUniqueName)
+                return CreationCollisionOption.GenerateUniqueName;
+            if (collisionOption == NameCollisionOption.ReplaceExisting)
+                return CreationCollisionOption.ReplaceExisting;
+
+            throw new NotSupportedException(collisionOption.ToString());
+        }
+
+        public static Windows.Storage.CreationCollisionOption ConvertToWindowsCreationCollisionOption(
+            CreationCollisionOption collisionOption)
+        {
+            if (collisionOption == CreationCollisionOption.FailIfExists)
+                return Windows.Storage.CreationCollisionOption.FailIfExists;
+            if (collisionOption == CreationCollisionOption.GenerateUniqueName)
+                return Windows.Storage.CreationCollisionOption.GenerateUniqueName;
+            if (collisionOption == CreationCollisionOption.ReplaceExisting)
+                return Windows.Storage.CreationCollisionOption.ReplaceExisting;
+            if (collisionOption == CreationCollisionOption.OpenIfExists)
+                return Windows.Storage.CreationCollisionOption.OpenIfExists;
+
+            throw new NotSupportedException(collisionOption.ToString());
+        }
+    }
+}

--- a/src/PCLExt.FileStorage.UWP/PCLExt.FileStorage.UWP.csproj
+++ b/src/PCLExt.FileStorage.UWP/PCLExt.FileStorage.UWP.csproj
@@ -170,7 +170,10 @@
     <Compile Include="..\PCLExt.FileStorage.Portable111\Requires.cs">
       <Link>Requires.cs</Link>
     </Compile>
+    <Compile Include="Extensions\StorageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StorageFileImplementation.cs" />
+    <Compile Include="StorageFolderImplementation.cs" />
     <EmbeddedResource Include="Properties\PCLExt.FileStorage.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PCLExt.FileStorage.UWP/PCLExt.FileStorage.UWP.csproj
+++ b/src/PCLExt.FileStorage.UWP/PCLExt.FileStorage.UWP.csproj
@@ -178,7 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.4.0</Version>
+      <Version>6.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/PCLExt.FileStorage.UWP/StorageFileImplementation.cs
+++ b/src/PCLExt.FileStorage.UWP/StorageFileImplementation.cs
@@ -1,0 +1,223 @@
+﻿using PCLExt.FileStorage.Extensions;
+using PCLExt.FileStorage.UWP.Extensions;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace PCLExt.FileStorage.UWP
+{
+    /// <inheritdoc />
+    sealed class StorageFileImplementation : IFile
+    {
+        public string Name => _storageFile.Name;
+
+        public string Path => _storageFile.Path;
+
+        private bool _exists = false;
+        public bool Exists => _exists;
+
+        public long Size =>
+            (long)_storageFile.GetBasicPropertiesAsync().AsTask().Result.Size;
+
+        public DateTime CreationTime =>
+            _storageFile.DateCreated.ToLocalTime().DateTime;
+
+        public DateTime CreationTimeUTC =>
+            _storageFile.DateCreated.ToUniversalTime().DateTime;
+
+        public DateTime LastAccessTime => _storageFile.GetBasicPropertiesAsync().
+            AsTask().Result.ItemDate.ToLocalTime().DateTime;
+
+        public DateTime LastAccessTimeUTC => _storageFile.GetBasicPropertiesAsync().
+            AsTask().Result.ItemDate.ToUniversalTime().DateTime;
+
+        public DateTime LastWriteTime => _storageFile.GetBasicPropertiesAsync().
+            AsTask().Result.DateModified.ToLocalTime().DateTime;
+
+        public DateTime LastWriteTimeUTC => _storageFile.GetBasicPropertiesAsync().
+            AsTask().Result.DateModified.ToUniversalTime().DateTime;
+
+        private StorageFile _storageFile;
+
+        /// <summary>
+        /// Creates a new <see cref="IFile"/> from StorageFile
+        /// </summary>
+        /// <param name="storageFile">StorageFile to keep in field</param>
+        public StorageFileImplementation(StorageFile storageFile)
+        {
+            _storageFile = storageFile;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IFile"/> corresponding to the specified path.
+        /// </summary>
+        /// <param name="path">The file path</param>
+        public StorageFileImplementation(string path)
+        {
+            try
+            {
+                _storageFile = StorageFile.GetFileFromPathAsync(path).AsTask().Result;
+            }
+            catch (FileNotFoundException)
+            {
+                _exists = false;
+                return;
+            }
+
+            _exists = true;
+        }
+
+        public async void Copy(IFile newFile)
+        {
+            var newFolder = await StorageFolder.GetFolderFromPathAsync(
+                System.IO.Path.GetDirectoryName(newFile.Path));
+            await _storageFile.CopyAsync(newFolder, newFile.Name);
+        }
+
+        public IFile Copy(string newPath, NameCollisionOption collisionOption = NameCollisionOption.ReplaceExisting)
+        {
+            return CopyAsync(newPath, collisionOption).Result;
+        }
+
+        public async Task CopyAsync(IFile newFile, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            var newFolder = await StorageFolder.GetFolderFromPathAsync(
+                 System.IO.Path.GetDirectoryName(newFile.Path)).
+                 AsTask(cancellationToken);
+            await _storageFile.CopyAsync(newFolder, newFile.Name).
+                AsTask(cancellationToken);
+        }
+
+       
+
+        public async Task<IFile> CopyAsync(string newPath, NameCollisionOption collisionOption = NameCollisionOption.ReplaceExisting, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            var newFolder = await StorageFolder.GetFolderFromPathAsync(
+                System.IO.Path.GetDirectoryName(newPath));
+            var newName = System.IO.Path.GetDirectoryName(newPath);
+            var windowsNameCollision = StorageExtensions. ConvertToNameCollision(collisionOption);
+            var newFile = await _storageFile.CopyAsync(
+                newFolder, newName, windowsNameCollision);
+            return new StorageFileImplementation(newFile.Path);
+        }
+
+        public void Delete()
+        {
+            _storageFile.DeleteAsync().AsTask().Wait();
+        }
+
+        public async Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            await _storageFile.DeleteAsync().AsTask(cancellationToken);
+        }
+
+        public async void Move(IFile newFile)
+        {
+            var newFolder = await StorageFolder.GetFolderFromPathAsync(
+                 System.IO.Path.GetDirectoryName(newFile.Path)).
+                 AsTask().ConfigureAwait(false);
+            await _storageFile.MoveAsync(newFolder);
+        }
+
+        public IFile Move(string newPath, NameCollisionOption collisionOption = NameCollisionOption.ReplaceExisting)
+        {
+            return MoveAsync(
+                newPath: newPath,
+                collisionOption: collisionOption).Result;
+        }
+
+        public async Task MoveAsync(IFile newFile, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await MoveAsync(
+                newPath: newFile.Path,
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<IFile> MoveAsync(string newPath, NameCollisionOption collisionOption = NameCollisionOption.ReplaceExisting, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            var newFolder = await StorageFolder.GetFolderFromPathAsync(
+                  System.IO.Path.GetDirectoryName(newPath));
+            var newName = System.IO.Path.GetFileName(newPath);
+            var windowsCollisionOption = StorageExtensions.ConvertToNameCollision(collisionOption);
+            await _storageFile.MoveAsync(newFolder, newName, windowsCollisionOption);
+            return new StorageFileImplementation(newPath);
+        }
+
+        public Stream Open(FileAccess fileAccess)
+        {
+            return OpenAsync(fileAccess).Result;
+        }
+
+        private FileAccessMode Convert(FileAccess fileAccess)
+        {
+            if (fileAccess == FileAccess.Read)
+                return FileAccessMode.Read;
+            if (fileAccess == FileAccess.ReadAndWrite)
+                return FileAccessMode.ReadWrite;
+            throw new NotSupportedException(fileAccess.ToString());
+        }
+
+        public async Task<Stream> OpenAsync(FileAccess fileAccess, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var windowsFileAccess = Convert(fileAccess);
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            var randomStream = await _storageFile.OpenAsync(windowsFileAccess).
+                AsTask(cancellationToken);
+            return randomStream.AsStream();
+        }
+
+        public byte[] ReadAllBytes()
+        {
+            return ReadAllBytesAsync().Result;
+        }
+
+        public async Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            byte[] result;
+            using (Stream stream = await _storageFile.OpenStreamForReadAsync())
+            {
+                using (var memoryStream = new MemoryStream())
+                {
+                    stream.CopyTo(memoryStream);
+                    result = memoryStream.ToArray();
+                }
+            }
+            return result;
+        }
+
+        public IFile Rename(string newName, NameCollisionOption collisionOption = NameCollisionOption.FailIfExists)
+        {
+            return RenameAsync(newName, collisionOption).Result;
+        }
+
+        public async Task<IFile> RenameAsync(string newName, NameCollisionOption collisionOption = NameCollisionOption.FailIfExists, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var windowsCollisionOption = StorageExtensions.ConvertToNameCollision(collisionOption);
+            var newFileName = System.IO.Path.GetFileName(newName);
+            await _storageFile.RenameAsync(newFileName, windowsCollisionOption);
+            return new StorageFileImplementation(_storageFile.Path);
+        }
+
+        public void WriteAllBytes(byte[] bytes)
+        {
+            WriteAllBytesAsync(bytes).Wait();
+        }
+
+        public async Task WriteAllBytesAsync(byte[] bytes, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await AwaitExtensions.SwitchOffMainThreadAsync(cancellationToken);
+            using (Stream stream = await _storageFile.OpenStreamForWriteAsync())
+            {
+                using (var sw = new BinaryWriter(stream))
+                    sw.Write(bytes);
+            }
+        }
+    }
+}

--- a/src/PCLExt.FileStorage.UWP/StorageFolderImplementation.cs
+++ b/src/PCLExt.FileStorage.UWP/StorageFolderImplementation.cs
@@ -1,0 +1,285 @@
+﻿using PCLExt.FileStorage.UWP.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Search;
+
+namespace PCLExt.FileStorage.UWP
+{
+    sealed class StorageFolderImplementation : IFolder
+    {
+        public string Name => _storageFolder.Name;
+
+        public string Path => _storageFolder.Path;
+
+        public bool Exists => true;
+
+        private readonly StorageFolder _storageFolder;
+
+        public StorageFolderImplementation(StorageFolder storageFolder)
+        {
+            _storageFolder = storageFolder;
+        }
+
+        public StorageFolderImplementation(String path)
+        {
+            _storageFolder = StorageFolder.GetFolderFromPathAsync(path).GetResults();
+        }
+
+        public ExistenceCheckResult CheckExists(string name)
+        {
+            return CheckExistsAsync(name).Result;
+        }
+
+        public async Task<ExistenceCheckResult> CheckExistsAsync(
+            string name, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var finded = await _storageFolder.GetItemAsync(name).AsTask(cancellationToken);
+            if (finded == null)
+            {
+                return ExistenceCheckResult.NotFound;
+            }
+
+            if (finded.Attributes == FileAttributes.Directory)
+            {
+                return ExistenceCheckResult.FolderExists;
+            }
+
+            return ExistenceCheckResult.FileExists;
+        }
+
+        public void Copy(
+            IFolder folder, 
+            NameCollisionOption option = NameCollisionOption.ReplaceExisting)
+        {
+            CopyAsync(folder, option).Wait();
+        }
+
+        public async Task CopyAsync(
+            IFolder folder, 
+            NameCollisionOption option = NameCollisionOption.ReplaceExisting, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var creationCollisionOption = StorageExtensions.ConvertToCreationCollision(option);
+            
+            var targetFolder = await folder.CreateFolderAsync(Name,
+                creationCollisionOption, cancellationToken) as StorageFolderImplementation;
+
+            if (targetFolder == null)
+                throw new Exception("Can't create StorageFolder");
+
+            // Get all files (shallow) from source
+            var queryOptions = new QueryOptions
+            {
+                IndexerOption = IndexerOption.DoNotUseIndexer,  // Avoid problems cause by out of sync indexer
+                FolderDepth = FolderDepth.Shallow,
+            };
+            var queryFiles = _storageFolder.CreateFileQueryWithOptions(queryOptions);
+            var files = await queryFiles.GetFilesAsync();
+
+            // Copy files into target folder
+            foreach (var storageFile in files)
+            {
+                await storageFile.CopyAsync(targetFolder._storageFolder, storageFile.Name,
+                    StorageExtensions.ConvertToNameCollision(option));
+            }
+
+            // Get all folders (shallow) from source
+            var queryFolders = _storageFolder.CreateFolderQueryWithOptions(queryOptions);
+            var folders = await queryFolders.GetFoldersAsync();
+
+            // For each folder call CopyAsync with new destination as destination
+            foreach (var storageFolder in folders)
+            {
+                await CopyAsync(GetFolder(storageFolder.Name), option, cancellationToken);
+            }
+        }
+
+        public IFile CreateFile(
+            string desiredName,
+            CreationCollisionOption option)
+        {
+            return CreateFileAsync(desiredName, option).Result;
+        }
+
+        public async Task<IFile> CreateFileAsync(
+            string desiredName, 
+            CreationCollisionOption option,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var windowsOption = StorageExtensions.
+                ConvertToWindowsCreationCollisionOption(option);
+            var file = await _storageFolder.CreateFileAsync(
+                desiredName, windowsOption).AsTask(cancellationToken);
+            return new StorageFileImplementation(file);
+        }
+
+        public IFolder CreateFolder(
+            string desiredName,
+            CreationCollisionOption option)
+        {
+            return CreateFolderAsync(desiredName, option).Result;
+        }
+
+        public async Task<IFolder> CreateFolderAsync(
+            string desiredName, 
+            CreationCollisionOption option, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var windowsOption = StorageExtensions.
+                ConvertToWindowsCreationCollisionOption(option);
+            var folder = await _storageFolder.CreateFolderAsync(
+                desiredName, windowsOption).AsTask(cancellationToken);
+            return new StorageFolderImplementation(folder);
+        }
+
+        public void Delete()
+        {
+            DeleteAsync().Wait();
+        }
+
+        public async Task DeleteAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await _storageFolder.DeleteAsync().AsTask(cancellationToken);
+        }
+
+        public IFile GetFile(string name)
+        {
+            return GetFileAsync(name).Result;
+        }
+
+        public async Task<IFile> GetFileAsync(
+            string name, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var storageFile = await _storageFolder.GetFileAsync(name).
+                AsTask(cancellationToken);
+            return new StorageFileImplementation(storageFile);
+        }
+
+        public IList<IFile> GetFiles(
+            string searchPattern = "*", 
+            FolderSearchOption searchOption = FolderSearchOption.TopFolderOnly)
+        {
+            return GetFilesAsync(searchPattern, searchOption).Result;
+        }
+
+        public async Task<IList<IFile>> GetFilesAsync(
+            string searchPattern = "*", 
+            FolderSearchOption searchOption = FolderSearchOption.TopFolderOnly,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var fileTypeFilter = new List<string>();
+            fileTypeFilter.Add("*");
+
+            var queryOptions = new QueryOptions(
+                CommonFileQuery.OrderBySearchRank, fileTypeFilter);
+
+            if (searchOption == FolderSearchOption.AllFolders)
+                queryOptions.FolderDepth = FolderDepth.Deep;
+            else if (searchOption == FolderSearchOption.TopFolderOnly)
+                queryOptions.FolderDepth = FolderDepth.Shallow;
+            else
+                throw new NotSupportedException(
+                    $"Not supported {nameof(searchOption)}: {searchOption}");
+
+            queryOptions.UserSearchFilter = searchPattern;
+            var queryResult = _storageFolder.
+                CreateFileQueryWithOptions(queryOptions);
+            var storageFiles = await queryResult.GetFilesAsync().
+                AsTask(cancellationToken);
+
+            return storageFiles.Select(
+                o => new StorageFileImplementation(o)).ToList<IFile>();
+        }
+
+        public IFolder GetFolder(string name)
+        {
+            return GetFolderAsync(name).Result;
+        }
+
+        public async Task<IFolder> GetFolderAsync(
+            string name, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var storageFolder = await _storageFolder.
+                GetFolderAsync(name).AsTask(cancellationToken);
+            return new StorageFolderImplementation(storageFolder);
+        }
+
+        public IList<IFolder> GetFolders()
+        {
+            return GetFoldersAsync().Result;
+        }
+
+        public async Task<IList<IFolder>> GetFoldersAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var storageFolders = await _storageFolder.
+                GetFoldersAsync().AsTask(cancellationToken);
+            return storageFolders.Select(
+                o => new StorageFolderImplementation(o)).ToList<IFolder>();
+        }
+
+        public void Move(
+            IFolder folder,
+            NameCollisionOption option = NameCollisionOption.ReplaceExisting)
+        {
+            MoveAsync(folder, option).Wait();
+        }
+
+        public async Task MoveAsync(
+            IFolder folder,
+            NameCollisionOption option = NameCollisionOption.ReplaceExisting,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var subfolders = await folder.GetFoldersAsync(cancellationToken);
+            foreach (var subfolder in subfolders)
+            {
+                var moveToSubfolderName = System.IO.Path.Combine(
+                    folder.Path, subfolder.Name);
+                var creationCollisionOption = default(CreationCollisionOption);
+                if (option == NameCollisionOption.ReplaceExisting)
+                    creationCollisionOption = CreationCollisionOption.ReplaceExisting;
+                else if (option == NameCollisionOption.GenerateUniqueName)
+                    creationCollisionOption = CreationCollisionOption.GenerateUniqueName;
+                else if (option == NameCollisionOption.FailIfExists)
+                    creationCollisionOption = CreationCollisionOption.FailIfExists;
+                else
+                    throw new NotSupportedException(
+                        $"Not supported {nameof(option)}: {option}");
+
+                var moveToSubfoler = await folder.CreateFolderAsync(
+                    subfolder.Name, creationCollisionOption);
+                await subfolder.MoveAsync(moveToSubfoler, option, cancellationToken);
+            }
+
+            var files = await folder.GetFilesAsync(
+                cancellationToken: cancellationToken);
+            foreach(var file in files)
+            {
+                var newFilePath = System.IO.Path.Combine(folder.Path, file.Name);
+                await file.MoveAsync(newFilePath, option, cancellationToken);
+            }
+        }
+
+        public IFolder Rename(string newName)
+        {
+            return RenameAsync(newName).Result;
+        }
+
+        public async Task<IFolder> RenameAsync(
+            string newName, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await _storageFolder.RenameAsync(newName).AsTask(cancellationToken);
+            return this;
+        }
+    }
+}

--- a/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
+++ b/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
@@ -224,7 +224,7 @@ namespace PCLExt.FileStorage.Test
         {
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.FailIfExists);
 
-            Assert.That(() => file.Open((FileAccess)2), Throws.ArgumentException);
+            Assert.That(() => file.Open((FileAccess) 2), Throws.ArgumentException);
         }
 
         #endregion
@@ -519,7 +519,7 @@ namespace PCLExt.FileStorage.Test
         {
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.FailIfExists);
 
-            Assert.That(() => file.Move(file.Path, (NameCollisionOption)3), Throws.ArgumentException);
+            Assert.That(() => file.Move(file.Path, (NameCollisionOption) 3), Throws.ArgumentException);
 
             file.Delete();
         }

--- a/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
+++ b/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
@@ -55,7 +55,8 @@ namespace PCLExt.FileStorage.Test
             var timeBeforeFileCreaton = DateTime.UtcNow;
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
 
-            Assert.True(timeBeforeFileCreaton <= file.CreationTimeUTC);
+            Assert.True(timeBeforeFileCreaton <= file.CreationTimeUTC,
+                $"{timeBeforeFileCreaton} <= {file.CreationTimeUTC}");
 
             file.Delete();
         }

--- a/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
+++ b/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
@@ -4,7 +4,7 @@ using System.IO;
 using NUnit.Framework;
 
 using PCLExt.FileStorage.Exceptions;
-using PCLExt.FileStorage.Extensions; 
+using PCLExt.FileStorage.Extensions;
 
 
 namespace PCLExt.FileStorage.Test
@@ -22,7 +22,7 @@ namespace PCLExt.FileStorage.Test
         [TearDown]
         public void Clean() => TestFolder.Delete();
 
-        #region Size
+        #region Size & Times
 
         [Test]
         public void Size()
@@ -34,6 +34,50 @@ namespace PCLExt.FileStorage.Test
             file.WriteAllBytes(data);
 
             Assert.IsTrue(file.Size == data.Length);
+
+            file.Delete();
+        }
+
+        [Test]
+        public void CreationTime()
+        {
+            var timeBeforeFileCreaton = DateTime.Now;
+            var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
+
+            Assert.True(timeBeforeFileCreaton <= file.CreationTime);
+
+            file.Delete();
+        }
+
+        [Test]
+        public void CreationTimeUTC()
+        {
+            var timeBeforeFileCreaton = DateTime.UtcNow;
+            var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
+
+            Assert.True(timeBeforeFileCreaton <= file.CreationTimeUTC);
+
+            file.Delete();
+        }
+
+        [Test]
+        public void LastAccessTime()
+        {
+            var timeBeforeFileCreaton = DateTime.Now;
+            var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
+
+            Assert.True(timeBeforeFileCreaton <= file.LastAccessTime);
+
+            file.Delete();
+        }
+
+        [Test]
+        public void LastAccessTimeUTC()
+        {
+            var timeBeforeFileCreaton = DateTime.UtcNow;
+            var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
+
+            Assert.True(timeBeforeFileCreaton <= file.LastAccessTimeUTC);
 
             file.Delete();
         }
@@ -179,7 +223,7 @@ namespace PCLExt.FileStorage.Test
         {
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.FailIfExists);
 
-            Assert.That(() => file.Open((FileAccess) 2), Throws.ArgumentException);
+            Assert.That(() => file.Open((FileAccess)2), Throws.ArgumentException);
         }
 
         #endregion
@@ -347,7 +391,7 @@ namespace PCLExt.FileStorage.Test
         {
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.FailIfExists);
 
-            Assert.That(() => file.Copy(file.Path, (NameCollisionOption) 3), Throws.ArgumentException);
+            Assert.That(() => file.Copy(file.Path, (NameCollisionOption)3), Throws.ArgumentException);
 
             file.Delete();
         }
@@ -474,7 +518,7 @@ namespace PCLExt.FileStorage.Test
         {
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.FailIfExists);
 
-            Assert.That(() => file.Move(file.Path, (NameCollisionOption) 3), Throws.ArgumentException);
+            Assert.That(() => file.Move(file.Path, (NameCollisionOption)3), Throws.ArgumentException);
 
             file.Delete();
         }

--- a/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
+++ b/test/PCLExt.FileStorage.NetFX.Test/FilesTest.cs
@@ -41,7 +41,7 @@ namespace PCLExt.FileStorage.Test
         [Test]
         public void CreationTime()
         {
-            var timeBeforeFileCreaton = DateTime.Now;
+            var timeBeforeFileCreaton = DateTime.Now.AddSeconds(-1);
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
 
             Assert.True(timeBeforeFileCreaton <= file.CreationTime);
@@ -52,11 +52,11 @@ namespace PCLExt.FileStorage.Test
         [Test]
         public void CreationTimeUTC()
         {
-            var timeBeforeFileCreaton = DateTime.UtcNow;
+            var timeBeforeFileCreaton = DateTime.UtcNow.AddSeconds(-1);
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
 
             Assert.True(timeBeforeFileCreaton <= file.CreationTimeUTC,
-                $"{timeBeforeFileCreaton} <= {file.CreationTimeUTC}");
+                $"{timeBeforeFileCreaton:yyyyMMddHHmmss.fff} <= {file.CreationTimeUTC:yyyyMMddHHmmss.fff}");
 
             file.Delete();
         }
@@ -64,7 +64,7 @@ namespace PCLExt.FileStorage.Test
         [Test]
         public void LastAccessTime()
         {
-            var timeBeforeFileCreaton = DateTime.Now;
+            var timeBeforeFileCreaton = DateTime.Now.AddSeconds(-1);
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
 
             Assert.True(timeBeforeFileCreaton <= file.LastAccessTime);
@@ -75,7 +75,7 @@ namespace PCLExt.FileStorage.Test
         [Test]
         public void LastAccessTimeUTC()
         {
-            var timeBeforeFileCreaton = DateTime.UtcNow;
+            var timeBeforeFileCreaton = DateTime.UtcNow.AddSeconds(-1);
             var file = TestFolder.CreateFile(FileName1, CreationCollisionOption.OpenIfExists);
 
             Assert.True(timeBeforeFileCreaton <= file.LastAccessTimeUTC);


### PR DESCRIPTION
There is an issue!!!
PCLExt.FileStorage.UWP.Test doesn't execute!

My investigation showed that only MsTest works for UWP unit testing. I created such project and tested the code but it required a lot of changed to all tests (at least changing attributes and some asserts because MsTest doesn't support them). I can add UWP testing in the next pull request. Or the author of the project can add it later.
 
Update reviews from the previous pull request. 
Mostly fixing async.
Times have been added to IFile StorageFolder & StorageFile have been implemented for UWP